### PR TITLE
Add install.sh for manual file-by-file OpenWrt theme install

### DIFF
--- a/luci-theme-saas-dark/install.sh
+++ b/luci-theme-saas-dark/install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+DEST_ROOT="${1:-/}"
+
+copy_file() {
+    src="$1"
+    dst="$2"
+    mode="$3"
+
+    src_path="$SCRIPT_DIR/$src"
+    dst_path="$DEST_ROOT/$dst"
+
+    if [ ! -f "$src_path" ]; then
+        echo "[ERROR] No se encontró: $src_path" >&2
+        exit 1
+    fi
+
+    install -D -m "$mode" "$src_path" "$dst_path"
+    echo "[OK] $src -> /$dst"
+}
+
+echo "Instalando luci-theme-saas-dark en: $DEST_ROOT"
+
+copy_file "luasrc/view/themes/saas-dark/header.htm" "usr/lib/lua/luci/view/themes/saas-dark/header.htm" "0644"
+copy_file "luasrc/view/themes/saas-dark/footer.htm" "usr/lib/lua/luci/view/themes/saas-dark/footer.htm" "0644"
+copy_file "luasrc/view/themes/saas-dark/index.htm" "usr/lib/lua/luci/view/themes/saas-dark/index.htm" "0644"
+copy_file "luasrc/view/themes/saas-dark/login.htm" "usr/lib/lua/luci/view/themes/saas-dark/login.htm" "0644"
+copy_file "luasrc/view/themes/saas-dark/partials/navigation.htm" "usr/lib/lua/luci/view/themes/saas-dark/partials/navigation.htm" "0644"
+copy_file "htdocs/luci-static/saas-dark/css/style.css" "www/luci-static/saas-dark/css/style.css" "0644"
+copy_file "htdocs/luci-static/saas-dark/js/theme.js" "www/luci-static/saas-dark/js/theme.js" "0644"
+copy_file "root/etc/uci-defaults/99-theme-saas-dark" "etc/uci-defaults/99-theme-saas-dark" "0755"
+
+echo "Instalación completada."
+echo "Si estás instalando directo en el router, aplica/asegura el theme con:"
+echo "  uci set luci.main.mediaurlbase='/luci-static/saas-dark'"
+echo "  uci commit luci"
+echo "  /etc/init.d/uhttpd restart"


### PR DESCRIPTION
### Motivation
- Permitir instalar el theme directamente en un sistema OpenWrt copiando archivos individuales en lugar de usar un paquete `.apk`.

### Description
- Añade `luci-theme-saas-dark/install.sh`, un script ejecutable que copia las vistas LuCI, los activos estáticos y el script `uci-defaults` a sus rutas finales, crea directorios según sea necesario, valida la existencia de los archivos y aplica permisos con `install -D -m`, y acepta un argumento opcional `DEST_ROOT` (por defecto `/`).

### Testing
- Se ejecutó el instalador contra un directorio temporal con `mktemp -d` y se verificó que todos los archivos esperados fueron copiados correctamente (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d959c0b0548327ba302de50821db12)