### PR TITLE
Add terminal Telegram Saved Messages downloader (tsmdownloader.py)

### DIFF
--- a/telegram-saved-messages-downloader/README.md
+++ b/telegram-saved-messages-downloader/README.md
@@ -1,0 +1,33 @@
+# Telegram Saved Messages Downloader
+
+Script de terminal para descargar todos los mensajes del chat **Saved Messages** de Telegram en orden cronológico.
+
+## Instalación
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install telethon rich
+```
+
+## Uso (una sola línea)
+
+```bash
+python tsmdownloader.py --api-id 123456 --api-hash abcdef123456 --phone +34123456789
+```
+
+## Opciones útiles
+
+- `--output-dir /ruta/custom` para cambiar la carpeta destino (por defecto `./messages`).
+- `--session mi_sesion` para reutilizar sesión.
+- `--code 12345` para pasar OTP por argumento.
+- `--password "mi_2fa"` para cuentas con 2FA.
+- `--limit 500` para pruebas.
+
+## Formato de nombres
+
+Prefijo de fecha:
+
+- `y2026m03d24h13m58s59-[NombreOriginal]` para media.
+- `y2026m03d24h13m58s59-Texto.txt` para texto normal.
+- `y2026m03d24h13m58s59-Texto.url` si el mensaje contiene únicamente una URL.

--- a/telegram-saved-messages-downloader/tsmdownloader.py
+++ b/telegram-saved-messages-downloader/tsmdownloader.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Telegram Saved Messages Downloader (terminal-first)."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from telethon import TelegramClient
+from telethon.errors import SessionPasswordNeededError
+from telethon.tl.custom.message import Message
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
+console = Console()
+URL_ONLY_PATTERN = re.compile(r"^https?://\S+$", re.IGNORECASE)
+SAFE_CHARS_PATTERN = re.compile(r"[^A-Za-z0-9._ -]+")
+
+
+@dataclass
+class Config:
+    api_id: int
+    api_hash: str
+    phone: Optional[str]
+    session: str
+    output_dir: Path
+    code: Optional[str]
+    password: Optional[str]
+    limit: Optional[int]
+
+
+def parse_args() -> Config:
+    parser = argparse.ArgumentParser(
+        description="Descarga todos los mensajes de 'Saved Messages' en archivos locales."
+    )
+    parser.add_argument("--api-id", type=int, required=True, help="Telegram API ID")
+    parser.add_argument("--api-hash", required=True, help="Telegram API hash")
+    parser.add_argument("--phone", help="Número de teléfono en formato internacional, ej: +34123456789")
+    parser.add_argument(
+        "--session",
+        default="tsm_session",
+        help="Nombre/ruta base del archivo de sesión de Telethon (default: tsm_session)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="messages",
+        help="Directorio de salida (default: ./messages)",
+    )
+    parser.add_argument("--code", help="Código OTP de Telegram (si no se pasa, se pedirá en terminal)")
+    parser.add_argument("--password", help="Contraseña 2FA (si aplica)")
+    parser.add_argument("--limit", type=int, help="Límite de mensajes a descargar (opcional)")
+
+    args = parser.parse_args()
+    return Config(
+        api_id=args.api_id,
+        api_hash=args.api_hash,
+        phone=args.phone,
+        session=args.session,
+        output_dir=Path(args.output_dir).expanduser().resolve(),
+        code=args.code,
+        password=args.password,
+        limit=args.limit,
+    )
+
+
+def sanitize_filename(value: str, fallback: str = "archivo") -> str:
+    cleaned = SAFE_CHARS_PATTERN.sub("_", value).strip(" ._")
+    return cleaned or fallback
+
+
+def date_prefix(dt: datetime) -> str:
+    return f"y{dt.year:04d}m{dt.month:02d}d{dt.day:02d}h{dt.hour:02d}m{dt.minute:02d}s{dt.second:02d}"
+
+
+def is_url_only(text: str) -> bool:
+    return bool(URL_ONLY_PATTERN.fullmatch(text.strip()))
+
+
+def write_text_file(message: Message, base_prefix: str, output_dir: Path) -> Path:
+    text = (message.message or "").strip()
+    extension = "url" if is_url_only(text) else "txt"
+    file_path = output_dir / f"{base_prefix}-Texto.{extension}"
+    file_path.write_text(text + "\n", encoding="utf-8")
+    return file_path
+
+
+async def ensure_login(client: TelegramClient, cfg: Config) -> None:
+    if await client.is_user_authorized():
+        return
+
+    if not cfg.phone:
+        raise RuntimeError(
+            "No hay sesión iniciada. Debes pasar --phone para autenticarte la primera vez."
+        )
+
+    await client.send_code_request(cfg.phone)
+    code = cfg.code or console.input("[bold cyan]Introduce el código OTP de Telegram:[/bold cyan] ")
+
+    try:
+        await client.sign_in(phone=cfg.phone, code=code)
+    except SessionPasswordNeededError:
+        password = cfg.password or console.input(
+            "[bold cyan]Cuenta con 2FA. Introduce contraseña:[/bold cyan] ", password=True
+        )
+        await client.sign_in(password=password)
+
+
+async def process_messages(client: TelegramClient, cfg: Config) -> tuple[int, int, int]:
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+    total_messages = 0
+    media_saved = 0
+    text_saved = 0
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        task = progress.add_task("Descargando Saved Messages...", total=None)
+
+        async for message in client.iter_messages("me", reverse=True, limit=cfg.limit):
+            total_messages += 1
+            timestamp = message.date.astimezone()
+            prefix = date_prefix(timestamp)
+
+            if message.media:
+                guessed_name = "Media"
+                if message.file and message.file.name:
+                    guessed_name = sanitize_filename(message.file.name, "Media")
+                target_name = f"{prefix}-{guessed_name}"
+                target_path = cfg.output_dir / target_name
+                saved_path = await client.download_media(message, file=target_path)
+
+                if saved_path:
+                    media_saved += 1
+
+            if (message.message or "").strip():
+                write_text_file(message, prefix, cfg.output_dir)
+                text_saved += 1
+
+            progress.update(task, description=f"Procesando mensaje #{total_messages}")
+
+        progress.update(task, total=total_messages, completed=total_messages)
+
+    return total_messages, media_saved, text_saved
+
+
+async def run(cfg: Config) -> int:
+    console.print(
+        Panel.fit(
+            "[bold green]Telegram Saved Messages Downloader[/bold green]\n"
+            "Exportación cronológica de todo tu chat personal.",
+            title="TSMDownloader",
+            border_style="cyan",
+        )
+    )
+
+    client = TelegramClient(cfg.session, cfg.api_id, cfg.api_hash)
+
+    async with client:
+        await ensure_login(client, cfg)
+        total, media_count, text_count = await process_messages(client, cfg)
+
+    console.print(
+        Panel.fit(
+            f"[bold]Mensajes procesados:[/bold] {total}\n"
+            f"[bold]Archivos multimedia:[/bold] {media_count}\n"
+            f"[bold]Archivos de texto/url:[/bold] {text_count}\n"
+            f"[bold]Carpeta de salida:[/bold] {cfg.output_dir}",
+            title="Resumen",
+            border_style="green",
+        )
+    )
+    return 0
+
+
+def main() -> None:
+    cfg = parse_args()
+    try:
+        raise SystemExit(asyncio.run(run(cfg)))
+    except KeyboardInterrupt:
+        console.print("\n[bold red]Cancelado por el usuario.[/bold red]")
+        raise SystemExit(130)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Proveer una herramienta de terminal para exportar todo el chat "Saved Messages" de Telegram a archivos locales con un formato de nombres consistente y apto para archivado cronológico.
- Facilitar ejecución «una sola línea» mediante argumentos para autenticación (API ID/Hash, teléfono, OTP y 2FA) y opción de cambiar la carpeta de salida.

### Description
- Añadido el proyecto `telegram-saved-messages-downloader` con el script principal `tsmdownloader.py` que usa `Telethon` para conectarse a Telegram y `Rich` para una interfaz CLI más profesional.
- Implementada la interfaz por línea de comandos con `--api-id`, `--api-hash`, `--phone`, `--session`, `--code`, `--password`, `--output-dir` y `--limit`.
- Descarga los mensajes de `Saved Messages` en orden cronológico y guarda cada elemento en `./messages` por defecto (o en `--output-dir`) usando el prefijo de fecha `yYYYYmMMdDDhHHmMMsSS-...` para todos los archivos.
- Guarda mensajes de texto en archivos separados `...-Texto.txt` y si el mensaje contiene únicamente una URL la guarda como `...-Texto.url`, además de guardar archivos multimedia con nombres tratados seguro por `sanitize_filename`.
- Añadido `README.md` con instrucciones de instalación, uso de una sola línea y descripción del formato de nombres.

### Testing
- Se ejecutó `python -m py_compile telegram-saved-messages-downloader/tsmdownloader.py` y la compilación pasó correctamente.
- No se añadieron tests unitarios automatizados en esta entrega.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97761abdc8327a64cbbfc9923997c)