### PR TITLE
docs: añadir tutorial para obtener api-id y api-hash

### DIFF
--- a/telegram-saved-messages-downloader/README.md
+++ b/telegram-saved-messages-downloader/README.md
@@ -16,6 +16,22 @@ source .venv/bin/activate
 pip install telethon rich
 ```
 
+## Cómo conseguir `api-id` y `api-hash`
+
+1. Inicia sesión en https://my.telegram.org con tu número de teléfono.
+2. Introduce el código que Telegram te envía (normalmente llega al propio Telegram).
+3. En el panel, entra a **API development tools**.
+4. Si es la primera vez, completa los campos de creación de app (por ejemplo:
+   - **App title**: `tsm-downloader`
+   - **Short name**: `tsmdownloader`
+   - **Platform**: `Desktop`
+   - **Description**: `Descarga de Saved Messages`
+5. Guarda el formulario. En la siguiente pantalla verás:
+   - **App api_id** → úsalo como valor de `--api-id`
+   - **App api_hash** → úsalo como valor de `--api-hash`
+
+> ⚠️ Trata tu `api-hash` como una contraseña: no lo publiques ni lo subas a repositorios.
+
 ## Uso (una sola línea)
 
 ```bash


### PR DESCRIPTION
### Motivation
- Añadir al `README` del descargador una guía breve para obtener `api-id` y `api-hash` desde `my.telegram.org` para que los usuarios puedan ejecutar la herramienta sin dudas.

### Description
- Se añadió la sección **Cómo conseguir `api-id` y `api-hash`** en `telegram-saved-messages-downloader/README.md` con pasos para iniciar sesión en `https://my.telegram.org`, usar `API development tools`, ejemplos de campos de app y una nota de seguridad sobre el `api-hash`.

### Testing
- Se ejecutaron los comandos `git status --short`, `git add telegram-saved-messages-downloader/README.md && git commit -m "docs: añadir tutorial para obtener api-id y api-hash"` y `nl -ba telegram-saved-messages-downloader/README.md | sed -n '1,260p'`, y todos completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e991253a70832793980853b763407f)