### PR TITLE
Añade opción `--count` para contar mensajes en Saved Messages

### DIFF
--- a/telegram-saved-messages-downloader/tsmdownloader.py
+++ b/telegram-saved-messages-downloader/tsmdownloader.py
@@ -150,6 +150,7 @@ class Config:
   code: Optional[str]
   password: Optional[str]
   limit: Optional[int]
+  count: bool
 
 def fParsearArgumentos() -> Config:
   vParser = argparse.ArgumentParser(
@@ -171,6 +172,11 @@ def fParsearArgumentos() -> Config:
   vParser.add_argument("--code", help="Código OTP de Telegram")
   vParser.add_argument("--password", help="Contraseña 2FA")
   vParser.add_argument("--limit", type=int, help="Límite de mensajes a descargar (opcional)")
+  vParser.add_argument(
+    "-c", "--count",
+    action="store_true",
+    help="Cuenta todos los mensajes en Saved Messages sin descargarlos"
+  )
 
   vArgs = vParser.parse_args()
 
@@ -182,7 +188,8 @@ def fParsearArgumentos() -> Config:
     output_dir=Path(vArgs.output_dir).expanduser().resolve(),
     code=vArgs.code,
     password=vArgs.password,
-    limit=vArgs.limit
+    limit=vArgs.limit,
+    count=vArgs.count
   )
 
 def fSanitizarNombreDeArchivo(pValor: str, pFallback: str = "archivo") -> str:
@@ -313,6 +320,26 @@ async def fProcesarMensajes(pClient: TelegramClient, pCfg: Config) -> tuple[int,
 
   return vTotalMensajes, vCantidadMedia, vCantidadTextos
 
+async def fContarMensajes(pClient: TelegramClient) -> int:
+  vTotalMensajes = 0
+
+  with Progress(
+    SpinnerColumn(),
+    TextColumn("[progress.description]{task.description}"),
+    TimeElapsedColumn(),
+    console=console
+  ) as vProgress:
+    vTask = vProgress.add_task("Contando mensajes en Saved Messages...", total=None)
+
+    async for _ in pClient.iter_messages("me"):
+      vTotalMensajes += 1
+      if vTotalMensajes % 100 == 0:
+        vProgress.update(vTask, description=f"Mensajes contados: {vTotalMensajes}")
+
+    vProgress.update(vTask, description=f"Mensajes contados: {vTotalMensajes}")
+
+  return vTotalMensajes
+
 async def fEjecutar(pCfg: Config) -> int:
   console.print(
     Panel.fit(
@@ -332,9 +359,22 @@ async def fEjecutar(pCfg: Config) -> int:
   try:
     await vClient.connect()
     await fAsegurarLogin(vClient, pCfg)
-    vTotal, vCantidadMedia, vCantidadTextos = await fProcesarMensajes(vClient, pCfg)
+    if pCfg.count:
+      vTotal = await fContarMensajes(vClient)
+    else:
+      vTotal, vCantidadMedia, vCantidadTextos = await fProcesarMensajes(vClient, pCfg)
   finally:
     await vClient.disconnect()
+
+  if pCfg.count:
+    console.print(
+      Panel.fit(
+        f"[bold]Mensajes en Saved Messages:[/bold] {vTotal}",
+        title="Conteo",
+        border_style="green"
+      )
+    )
+    return 0
 
   console.print(
     Panel.fit(


### PR DESCRIPTION
### Motivation
- Permitir contar cuántos mensajes hay en el chat "Saved Messages" sin descargar los archivos para obtener rápidamente el tamaño del historial.

### Description
- Se añadió el campo `count: bool` a la `dataclass Config` y el argumento de CLI `-c/--count` al parser en `tsmdownloader.py`.
- Se implementó la rutina asíncrona `fContarMensajes(pClient: TelegramClient) -> int` que itera sobre `pClient.iter_messages("me")`, acumula el total y muestra progreso con `rich.Progress` sin descargar medios.
- Se actualizó `fEjecutar` para que, cuando `pCfg.count` sea verdadero, autentique, ejecute `fContarMensajes`, muestre un `Panel` con el conteo y termine sin ejecutar la lógica de descarga; cuando no se usa `--count` se mantiene el flujo previo de descarga/exportación.
- En modo conteo se omite la descarga de archivos y `--limit` queda sin efecto (se recorre todo el historial de `Saved Messages`).

### Testing
- Se compiló el archivo con `python3 -m py_compile telegram-saved-messages-downloader/tsmdownloader.py` y la comprobación automática terminó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9981bc0d88327b8b516e866befffc)