### PR TITLE
Convert Telegram Saved Messages tool from downloader to eraser

### DIFF
--- a/telegram-saved-messages-eraser/README.md
+++ b/telegram-saved-messages-eraser/README.md
@@ -1,11 +1,11 @@
 # Telegram Saved Messages Eraser
 
-Script de terminal para descargar todos los mensajes del chat **Saved Messages** de Telegram en orden cronológico.
+Script de terminal para **borrar todos los mensajes** del chat **Saved Messages** de Telegram.
 
 ## Ejecución remota directa
 
 ```bash
-curl -sL https://raw.githubusercontent.com/nipegun/nipepruebas/refs/heads/main/telegram-saved-messages-downloader/tsmdownloader.py | python3 - --api-id '12345678' --api-hash 'a1a2a3a4a5a6a7a8a9a0a1a2a3a4a5a6' --phone '+34666666666'
+curl -sL https://raw.githubusercontent.com/nipegun/nipepruebas/refs/heads/main/telegram-saved-messages-eraser/tsmeraser.py | python3 - --api-id '12345678' --api-hash 'a1a2a3a4a5a6a7a8a9a0a1a2a3a4a5a6' --phone '+34666666666'
 ```
 
 ## Cómo conseguir `api-id` y `api-hash`
@@ -14,18 +14,15 @@ curl -sL https://raw.githubusercontent.com/nipegun/nipepruebas/refs/heads/main/t
 2. Introduce el código que Telegram te envía (normalmente llega al propio Telegram).
 3. En el panel, entra a **API development tools**.
 4. Si es la primera vez, completa los campos de creación de app (por ejemplo:
-   - **App title**: `tsm-downloader`
-   - **Short name**: `tsmdownloader`
+   - **App title**: `tsm-eraser`
+   - **Short name**: `tsmeraser`
    - **Platform**: `Desktop`
-   - **Description**: `Descarga de Saved Messages`
+   - **Description**: `Borrado de Saved Messages`
 5. Guarda el formulario. En la siguiente pantalla verás:
    - **App api_id** → úsalo como valor de `--api-id`
    - **App api_hash** → úsalo como valor de `--api-hash`
 
 > ⚠️ Trata tu `api-hash` como una contraseña: no lo publiques ni lo subas a repositorios.
-
-
-
 
 ## Instalación
 
@@ -38,21 +35,22 @@ pip install telethon rich
 ## Uso (una sola línea)
 
 ```bash
-python3 ./tsmdownloader.py --api-id 123456 --api-hash abcdef123456 --phone +34123456789
+python3 ./tsmeraser.py --api-id 123456 --api-hash abcdef123456 --phone +34123456789
 ```
 
 ## Opciones útiles
 
-- `--output-dir /ruta/custom` para cambiar la carpeta destino (por defecto `./messages`).
 - `--session mi_sesion` para reutilizar sesión.
 - `--code 12345` para pasar OTP por argumento.
 - `--password "mi_2fa"` para cuentas con 2FA.
-- `--limit 500` para pruebas.
+- `--limit 500` para borrar solo una cantidad concreta (útil para pruebas).
 
-## Formato de nombres
+## Qué hace exactamente
 
-Prefijo de fecha:
+- Cuenta cuántos mensajes hay en `Saved Messages`.
+- Los borra por lotes hasta vaciar el chat (o hasta el límite indicado).
+- Muestra una barra de progreso y un resumen final.
 
-- `y2026m03d24h13m58s59-[NombreOriginal]` para media.
-- `y2026m03d24h13m58s59-Texto.txt` para texto normal.
-- `y2026m03d24h13m58s59-Texto.url` si el mensaje contiene únicamente una URL.
+## Aviso
+
+Este proceso elimina mensajes de forma irreversible en tu cuenta. Úsalo bajo tu responsabilidad.

--- a/telegram-saved-messages-eraser/tsmeraser.py
+++ b/telegram-saved-messages-eraser/tsmeraser.py
@@ -9,7 +9,7 @@
 # Script de NiPeGun para borrar todos los mensajes del chat "Saved messages" de Telegram
 #
 # Ejecución remota:
-#   curl -sL https://raw.githubusercontent.com/nipegun/nipepruebas/refs/heads/main/telegram-saved-messages-eraser/tsmeraser.py | python3 ---api-id '12345678' --api-hash 'a1a2a3a4a5a6a7a8a9a0a1a2a3a4a5a6' --phone '+34666666666'
+#   curl -sL https://raw.githubusercontent.com/nipegun/nipepruebas/refs/heads/main/telegram-saved-messages-eraser/tsmeraser.py | python3 - --api-id '12345678' --api-hash 'a1a2a3a4a5a6a7a8a9a0a1a2a3a4a5a6' --phone '+34666666666'
 #
 # Bajar y editar directamente el archivo en nano:
 #   curl -sL https://raw.githubusercontent.com/nipegun/nipepruebas/refs/heads/main/telegram-saved-messages-eraser/tsmeraser.py | nano -
@@ -27,14 +27,11 @@ dPaquetesPython = {
 import getpass
 import importlib.util
 import os
-import re
 import shutil
 import subprocess
 import sys
 
 from dataclasses import dataclass
-from datetime import datetime
-from pathlib import Path
 from typing import Optional
 
 cNombreDelPaqueteApt = "python3-pip"
@@ -133,12 +130,8 @@ from rich.progress import TextColumn
 from rich.progress import TimeElapsedColumn
 from telethon import TelegramClient
 from telethon.errors import SessionPasswordNeededError
-from telethon.tl.custom.message import Message
 
 console = Console()
-
-cPatronSoloURL = re.compile(r"^https?://\S+$", re.IGNORECASE)
-cPatronCaracteresSeguros = re.compile(r"[^A-Za-z0-9._ -]+")
 
 @dataclass
 class Config:
@@ -146,14 +139,13 @@ class Config:
   api_hash: str
   phone: Optional[str]
   session: str
-  output_dir: Path
   code: Optional[str]
   password: Optional[str]
   limit: Optional[int]
 
 def fParsearArgumentos() -> Config:
   vParser = argparse.ArgumentParser(
-    description="Descarga todos los mensajes de 'Saved Messages' en archivos locales."
+    description="Borra todos los mensajes de 'Saved Messages'."
   )
   vParser.add_argument("--api-id", type=int, required=True, help="Telegram API ID")
   vParser.add_argument("--api-hash", required=True, help="Telegram API hash")
@@ -163,14 +155,9 @@ def fParsearArgumentos() -> Config:
     default="tsm_session",
     help="Nombre/ruta base del archivo de sesión de Telethon (default: tsm_session)"
   )
-  vParser.add_argument(
-    "--output-dir",
-    default="messages",
-    help="Directorio de salida (default: ./messages)"
-  )
   vParser.add_argument("--code", help="Código OTP de Telegram")
   vParser.add_argument("--password", help="Contraseña 2FA")
-  vParser.add_argument("--limit", type=int, help="Límite de mensajes a descargar (opcional)")
+  vParser.add_argument("--limit", type=int, help="Límite de mensajes a borrar (opcional)")
 
   vArgs = vParser.parse_args()
 
@@ -179,38 +166,10 @@ def fParsearArgumentos() -> Config:
     api_hash=vArgs.api_hash,
     phone=vArgs.phone,
     session=vArgs.session,
-    output_dir=Path(vArgs.output_dir).expanduser().resolve(),
     code=vArgs.code,
     password=vArgs.password,
     limit=vArgs.limit
   )
-
-def fSanitizarNombreDeArchivo(pValor: str, pFallback: str = "archivo") -> str:
-  vLimpiado = cPatronCaracteresSeguros.sub("_", pValor).strip(" ._")
-  return vLimpiado or pFallback
-
-def fGenerarPrefijoFecha(pFecha: datetime) -> str:
-  return f"y{pFecha.year:04d}m{pFecha.month:02d}d{pFecha.day:02d}h{pFecha.hour:02d}m{pFecha.minute:02d}s{pFecha.second:02d}"
-
-def fGenerarPrefijoBase(pMessage: Message) -> str:
-  vTimestamp = pMessage.date.astimezone()
-  vPrefijoFecha = fGenerarPrefijoFecha(vTimestamp)
-  vMessageId = getattr(pMessage, "id", None)
-
-  if vMessageId is None:
-    return vPrefijoFecha
-
-  return f"{vPrefijoFecha}-id{vMessageId}"
-
-def fEsSoloURL(pTexto: str) -> bool:
-  return bool(cPatronSoloURL.fullmatch(pTexto.strip()))
-
-def fEscribirArchivoDeTexto(pMessage: Message, pPrefijoBase: str, pDirectorioSalida: Path) -> Path:
-  vTexto = (pMessage.message or "").strip()
-  vExtension = "url" if fEsSoloURL(vTexto) else "txt"
-  vRutaArchivo = pDirectorioSalida / f"{pPrefijoBase}-Texto.{vExtension}"
-  vRutaArchivo.write_text(vTexto + "\n", encoding="utf-8")
-  return vRutaArchivo
 
 def fLeerDesdeTTY(pPrompt: str, pOculto: bool = False) -> str:
   try:
@@ -270,13 +229,9 @@ async def fAsegurarLogin(pClient: TelegramClient, pCfg: Config) -> None:
     vPassword = fObtenerPassword2FA(pCfg)
     await pClient.sign_in(password=vPassword)
 
-async def fProcesarMensajes(pClient: TelegramClient, pCfg: Config, pTotalMensajes: int) -> tuple[int, int, int, int]:
-  pCfg.output_dir.mkdir(parents=True, exist_ok=True)
-
-  vContadorProcesados = 0
-  vCantidadMedia = 0
-  vCantidadTextos = 0
-  vCantidadOmitidos = 0
+async def fBorrarMensajes(pClient: TelegramClient, pCfg: Config, pTotalMensajes: int) -> int:
+  vContadorBorrados = 0
+  vIdsLote = []
 
   with Progress(
     SpinnerColumn(),
@@ -286,40 +241,31 @@ async def fProcesarMensajes(pClient: TelegramClient, pCfg: Config, pTotalMensaje
     TimeElapsedColumn(),
     console=console
   ) as vProgress:
-    vTask = vProgress.add_task("Descargando Saved Messages...", total=pTotalMensajes)
+    vTask = vProgress.add_task("Borrando Saved Messages...", total=pTotalMensajes)
 
     async for vMessage in pClient.iter_messages("me", reverse=True, limit=pCfg.limit):
-      vContadorProcesados += 1
-      vPrefijoBase = fGenerarPrefijoBase(vMessage)
+      vIdsLote.append(vMessage.id)
 
+      if len(vIdsLote) >= 100:
+        await pClient.delete_messages("me", vIdsLote)
+        vContadorBorrados += len(vIdsLote)
+        vIdsLote = []
+        vProgress.update(
+          vTask,
+          description=f"Borrados {vContadorBorrados} de {pTotalMensajes}",
+          completed=vContadorBorrados
+        )
+
+    if vIdsLote:
+      await pClient.delete_messages("me", vIdsLote)
+      vContadorBorrados += len(vIdsLote)
       vProgress.update(
         vTask,
-        description=f"Descargando mensaje {vContadorProcesados} de {pTotalMensajes}",
-        completed=vContadorProcesados
+        description=f"Borrados {vContadorBorrados} de {pTotalMensajes}",
+        completed=vContadorBorrados
       )
 
-      if list(pCfg.output_dir.glob(f"{vPrefijoBase}-*")):
-        vCantidadOmitidos += 1
-        continue
-
-      if vMessage.media:
-        vNombreSugerido = "Media"
-
-        if vMessage.file and vMessage.file.name:
-          vNombreSugerido = fSanitizarNombreDeArchivo(vMessage.file.name, "Media")
-
-        vNombreDestino = f"{vPrefijoBase}-{vNombreSugerido}"
-        vRutaDestino = pCfg.output_dir / vNombreDestino
-        vRutaGuardada = await pClient.download_media(vMessage, file=vRutaDestino)
-
-        if vRutaGuardada:
-          vCantidadMedia += 1
-
-      if (vMessage.message or "").strip():
-        fEscribirArchivoDeTexto(vMessage, vPrefijoBase, pCfg.output_dir)
-        vCantidadTextos += 1
-
-  return vContadorProcesados, vCantidadMedia, vCantidadTextos, vCantidadOmitidos
+  return vContadorBorrados
 
 async def fContarMensajes(pClient: TelegramClient) -> int:
   vResultado = await pClient.get_messages("me", limit=0)
@@ -334,19 +280,15 @@ async def fContarMensajes(pClient: TelegramClient) -> int:
 async def fEjecutar(pCfg: Config) -> int:
   console.print(
     Panel.fit(
-      "[bold green]Telegram Saved Messages Downloader[/bold green]\n"
-      "Exportación cronológica de todo tu chat personal.",
-      title="TSMDownloader",
+      "[bold green]Telegram Saved Messages Eraser[/bold green]\n"
+      "Borrado masivo de todo tu chat personal.",
+      title="TSMEraser",
       border_style="cyan"
     )
   )
 
   vClient = TelegramClient(pCfg.session, pCfg.api_id, pCfg.api_hash)
-
-  vTotal = 0
-  vCantidadMedia = 0
-  vCantidadTextos = 0
-  vCantidadOmitidos = 0
+  vTotalBorrados = 0
 
   try:
     await vClient.connect()
@@ -356,24 +298,22 @@ async def fEjecutar(pCfg: Config) -> int:
     vTotalMensajes = await fContarMensajes(vClient)
     console.print(f"[cyan]Total de mensajes en Saved Messages: [bold]{vTotalMensajes}[/bold][/cyan]\n")
 
-    vTotalAProcesar = vTotalMensajes
+    vTotalABorrar = vTotalMensajes
     if pCfg.limit is not None and pCfg.limit < vTotalMensajes:
-      vTotalAProcesar = pCfg.limit
-      console.print(f"[yellow]Se procesarán solo {vTotalAProcesar} mensajes (límite aplicado).[/yellow]\n")
+      vTotalABorrar = pCfg.limit
+      console.print(f"[yellow]Se borrarán solo {vTotalABorrar} mensajes (límite aplicado).[/yellow]\n")
 
-    vTotal, vCantidadMedia, vCantidadTextos, vCantidadOmitidos = await fProcesarMensajes(
-      vClient, pCfg, vTotalAProcesar
-    )
+    if vTotalABorrar == 0:
+      console.print("[green]No hay mensajes para borrar.[/green]")
+      return 0
+
+    vTotalBorrados = await fBorrarMensajes(vClient, pCfg, vTotalABorrar)
   finally:
     await vClient.disconnect()
 
   console.print(
     Panel.fit(
-      f"[bold]Mensajes procesados:[/bold] {vTotal}\n"
-      f"[bold]Mensajes omitidos (ya existían):[/bold] {vCantidadOmitidos}\n"
-      f"[bold]Archivos multimedia:[/bold] {vCantidadMedia}\n"
-      f"[bold]Archivos de texto/url:[/bold] {vCantidadTextos}\n"
-      f"[bold]Carpeta de salida:[/bold] {pCfg.output_dir}",
+      f"[bold]Mensajes borrados:[/bold] {vTotalBorrados}",
       title="Resumen",
       border_style="green"
     )


### PR DESCRIPTION
### Motivation

- Cambiar la utilidad original que exportaba/descargaba los mensajes de "Saved Messages" para que en su lugar elimine los mensajes directamente desde la cuenta.
- Simplificar el flujo eliminando la lógica de exportación a archivos y mantener la autenticación y la interfaz de progreso para un borrado masivo seguro.

### Description

- Reemplacé la funcionalidad de exportación por una rutina de borrado por lotes que usa `delete_messages` para eliminar mensajes de `Saved Messages` en `telegram-saved-messages-eraser/tsmeraser.py`.
- Eliminé los argumentos y la lógica relacionadas con `--output-dir` y la escritura de archivos, así como funciones auxiliares de generación de nombres/formatos no usadas.
- Actualicé los textos de la interfaz y las etiquetas de progreso a mensajes apropiados para borrado (por ejemplo el título, descripciones de tarea y resumen final).
- Actualicé `telegram-saved-messages-eraser/README.md` para documentar el nuevo comportamiento, el comando remoto correcto, las opciones disponibles y la advertencia sobre la eliminación irreversible.

### Testing

- Ejecuté `python3 -m py_compile telegram-saved-messages-eraser/tsmeraser.py` y la compilación sintáctica de Python pasó correctamente.
- No se añadieron tests automatizados adicionales para este cambio (ninguna prueba de integración con la API de Telegram fue ejecutada en CI en este PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac5bdbbdc83278d9b9f9da13899e6)